### PR TITLE
docs: adjust installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The goal of this library is to provide access to the complete expressiveness of 
 
 ```toml
 [dependencies]
-nft = "0.1"
+nftables = "0.2.0"
 ```
 
 ## Example


### PR DESCRIPTION
I noticed that the instructions in the README file haven't been updated yet. This PR proposes a trivial fix :)