### PR TITLE
Fix insert

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -49,7 +49,7 @@ pub enum NfCmd {
     Add(NfListObject), // TODO: CT_*
     Replace(Rule),
     Create(NfListObject), // TODO: ADD_OBJECT
-    Insert(Rule),
+    Insert(NfListObject),
     Delete(NfListObject), // TODO: ADD_OBJECT
     List(NfListObject),
     Reset(ResetObject),

--- a/tests/helper_tests.rs
+++ b/tests/helper_tests.rs
@@ -1,4 +1,4 @@
-use nft::{batch::Batch, helper, schema, types};
+use nftables::{batch::Batch, helper, schema, types};
 
 #[test]
 #[ignore]
@@ -12,7 +12,7 @@ fn test_list_ruleset() {
 /// Applies a ruleset to nftables.
 fn test_apply_ruleset() {
     let ruleset = example_ruleset();
-    nft::helper::apply_ruleset(&ruleset, None, None).unwrap();
+    nftables::helper::apply_ruleset(&ruleset, None, None).unwrap();
 }
 
 fn example_ruleset() -> schema::Nftables {

--- a/tests/json_tests.rs
+++ b/tests/json_tests.rs
@@ -1,4 +1,4 @@
-use nft::{schema::*, types::*};
+use nftables::{schema::*, types::*};
 use serde_json::json;
 use std::fs::{self, File};
 use std::io::BufReader;

--- a/tests/json_tests.rs
+++ b/tests/json_tests.rs
@@ -1,3 +1,5 @@
+use nftables::expr::{Expression, Meta, MetaKey, NamedExpression};
+use nftables::stmt::{Match, Operator, Statement};
 use nftables::{schema::*, types::*};
 use serde_json::json;
 use std::fs::{self, File};
@@ -46,6 +48,45 @@ fn test_chain_table_rule_inet() {
         ],
     };
     let json = json!({"nftables":[{"add":{"table":{"family":"inet","name":"some_inet_table"}}},{"add":{"chain":{"family":"inet","table":"some_inet_table","name":"some_inet_chain","type":"filter","hook":"forward","policy":"accept"}}}]});
+    println!("{}", &json);
+    let parsed: Nftables = serde_json::from_value(json).unwrap();
+    assert_eq!(expected, parsed);
+}
+
+#[test]
+fn test_insert() {
+    // nft insert rule inet some_inet_table some_inet_chain position 0 iifname "br-lan" oifname "wg_exit" counter accept
+    let expected: Nftables = Nftables {
+        objects: vec![NfObject::CmdObject(NfCmd::Insert(NfListObject::Rule(
+            Rule {
+                family: NfFamily::INet,
+                table: "some_inet_table".to_string(),
+                chain: "some_inet_chain".to_string(),
+                expr: vec![
+                    Statement::Match(Match {
+                        left: Expression::Named(NamedExpression::Meta(Meta {
+                            key: MetaKey::Iifname,
+                        })),
+                        right: Expression::String("br-lan".to_string()),
+                        op: Operator::EQ,
+                    }),
+                    Statement::Match(Match {
+                        left: Expression::Named(NamedExpression::Meta(Meta {
+                            key: MetaKey::Oifname,
+                        })),
+                        right: Expression::String("wg_exit".to_string()),
+                        op: Operator::EQ,
+                    }),
+                    Statement::Counter(None),
+                    Statement::Accept(None),
+                ],
+                handle: None,
+                index: Some(0),
+                comment: None,
+            },
+        )))],
+    };
+    let json = json!({"nftables":[{"insert":{"rule":{"family":"inet","table":"some_inet_table","chain":"some_inet_chain","expr":[{"match":{"left":{"meta":{"key":"iifname"}},"right":"br-lan","op":"=="}},{"match":{"left":{"meta":{"key":"oifname"}},"right":"wg_exit","op":"=="}},{"counter":null},{"accept":null}],"index":0,"comment":null}}}]});
     println!("{}", &json);
     let parsed: Nftables = serde_json::from_value(json).unwrap();
     assert_eq!(expected, parsed);

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -1,4 +1,4 @@
-use nft::{expr::*, schema::*, stmt::*, types::*};
+use nftables::{expr::*, schema::*, stmt::*, types::*};
 
 #[test]
 fn test_serialize() {


### PR DESCRIPTION
Previously adding an insert Rule directly to  an NfCmd::Insert was leaving out the necessary `{"insert": ...}` json object from the output.  By changing NfCmd::Insert to take an NfListObject, it matches how the ::Add command works and fixes the output.