### PR TITLE
Update queue flags to be optional

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -384,6 +384,7 @@ pub struct Queue {
     /// Queue number.
     pub num: Expression,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Queue flags.
     pub flags: Option<HashSet<QueueFlag>>,
 }

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -385,7 +385,7 @@ pub struct Queue {
     pub num: Expression,
 
     /// Queue flags.
-    pub flags: HashSet<QueueFlag>,
+    pub flags: Option<HashSet<QueueFlag>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/tests/json_tests.rs
+++ b/tests/json_tests.rs
@@ -1,5 +1,5 @@
 use nftables::expr::{Expression, Meta, MetaKey, NamedExpression};
-use nftables::stmt::{Match, Operator, Statement};
+use nftables::stmt::{Match, Operator, Queue, Statement};
 use nftables::{schema::*, types::*};
 use serde_json::json;
 use std::fs::{self, File};
@@ -88,6 +88,69 @@ fn test_insert() {
     };
     let json = json!({"nftables":[{"insert":{"rule":{"family":"inet","table":"some_inet_table","chain":"some_inet_chain","expr":[{"match":{"left":{"meta":{"key":"iifname"}},"right":"br-lan","op":"=="}},{"match":{"left":{"meta":{"key":"oifname"}},"right":"wg_exit","op":"=="}},{"counter":null},{"accept":null}],"index":0,"comment":null}}}]});
     println!("{}", &json);
+    let parsed: Nftables = serde_json::from_value(json).unwrap();
+    assert_eq!(expected, parsed);
+}
+
+#[test]
+fn test_parsing_of_queue_without_flags() {
+    let expected = Nftables {
+        objects: vec![NfObject::ListObject(NfListObject::Rule(Rule {
+            family: NfFamily::IP,
+            table: "test_table".to_string(),
+            chain: "test_chain".to_string(),
+            expr: vec![
+                Statement::Match(Match {
+                    left: Expression::Named(NamedExpression::Payload(nftables::expr::Payload {
+                        protocol: "udp".to_string(),
+                        field: "dport".to_string(),
+                    })),
+                    right: Expression::Number(20000),
+                    op: Operator::EQ,
+                }),
+                Statement::Queue(Queue {
+                    num: Expression::Number(0),
+                    flags: None,
+                }),
+            ],
+            handle: Some(2),
+            index: None,
+            comment: None,
+        }))],
+    };
+
+    let json = json!({
+        "nftables": [
+            {
+                "rule": {
+                    "family": "ip",
+                    "table": "test_table",
+                    "chain": "test_chain",
+                    "handle": 2,
+                    "expr": [
+                    {
+                        "match": {
+                            "op": "==",
+                            "left": {
+                                "payload": {
+                                    "protocol": "udp",
+                                    "field": "dport"
+                                }
+                            },
+                            "right": 20000
+                        }
+                    },
+                    {
+                        "queue": {
+                            "num": 0
+                        }
+                    }
+                ]
+                }
+            }
+        ]
+    });
+
     let parsed: Nftables = serde_json::from_value(json).unwrap();
     assert_eq!(expected, parsed);
 }

--- a/tests/json_tests.rs
+++ b/tests/json_tests.rs
@@ -154,3 +154,14 @@ fn test_parsing_of_queue_without_flags() {
     let parsed: Nftables = serde_json::from_value(json).unwrap();
     assert_eq!(expected, parsed);
 }
+
+#[test]
+fn test_queue_json_serialisation() {
+    let queue = Statement::Queue(Queue {
+        num: Expression::Number(0),
+        flags: None,
+    });
+
+    let expected_json = String::from(r#"{"queue":{"num":0}}"#);
+    assert_eq!(expected_json, serde_json::to_string(&queue).unwrap());
+}


### PR DESCRIPTION
Set the `Queue` flags to be optional because they may not always be provided. For example running the below commands would result in an output `JSON` that would cause the library to return an error when parsing.

```bash
sudo nft add table ip mytable
sudo nft add chain ip mytable out-chain "{ type filter hook output priority 0;}"
sudo nft add rule ip mytable out-chain udp dport 20000 queue num 0
```

This `PR` fixes this issue by setting the queue flags as optional. An associated unit test has been added to verify functionality.