### PR TITLE
Fix anonymous sets and XT

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+use crate::stmt::Statement;
+
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 /// Expressions are the building blocks of (most) statements.
@@ -26,7 +28,7 @@ pub enum NamedExpression {
     Concat(Vec<Expression>),
     /// This object constructs an anonymous set.
     /// For mappings, an array of arrays with exactly two elements is expected.
-    Set(Vec<Expression>),
+    Set(Vec<SetItem>),
     Map(Box<Map>),
     Prefix(Prefix),
 
@@ -58,6 +60,19 @@ pub struct Map {
     /// Mapping expression consisting of value/target pairs.
     pub data: Expression,
 }
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+/// Item in an anonymous set.
+pub enum SetItem{
+    /// A set item containing a single expression.
+    Element(Expression),
+    /// A set item mapping two expressions.
+    Mapping(Expression, Expression),
+    /// A set item mapping an expression to a statement.
+    MappingStatement(Expression, Statement),
+}
+
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename = "prefix")]

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -118,10 +118,10 @@ pub struct Match {
 pub struct Counter {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Packets counted.
-    pub packets: Option<u32>,
+    pub packets: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Bytes counted.
-    pub bytes: Option<u32>,
+    pub bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -74,7 +74,7 @@ pub enum Statement {
 
     /// This represents an xt statement from xtables compat interface.
     /// Sadly, at this point, it is not possible to provide any further information about its content.
-    XT(Option<bool>),
+    XT(Option<serde_json::Value>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This MR fixes the following problems:

* Set item only support single elements
* XT only be parsed as `bool`
* Counter values are only u32.