### PR TITLE
Fix TCP option key name

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -36,6 +36,7 @@ pub enum NamedExpression {
     #[serde(rename = "payload")]
     PayloadRaw(PayloadRaw),
     Exthdr(Exthdr),
+    #[serde(rename = "tcp option")]
     TcpOption(TcpOption),
     SctpChunk(SctpChunk),
     Meta(Meta),


### PR DESCRIPTION
According to https://manpages.debian.org/testing/libnftables1/libnftables-json.5.en.html the key should be `tcp option`, not `tcpoption`.
Tested with the following rule:
`nft 'add rule ip mangle FORWARD tcp flags syn / syn,rst counter tcp option maxseg size set rt mtu'`
and the following example code:
```rust
use nftables::helper::get_current_ruleset;

fn main() {
    let _set = get_current_ruleset(None, None).unwrap();
    println!("Rules were parsed successfully");
}
```

Before the fix:
```
thread 'main' panicked at examples/pr.rs:4:48:
called `Result::unwrap()` on an `Err` value: NftInvalidJson(Error("data did not match any variant of untagged enum NfObject", line: 1, column: 1296))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
After the fix:
```
Rules were parsed successfully
```