### PR TITLE
Implement map support

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 use crate::stmt::Statement;
+use crate::stmt::JumpTarget;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -18,6 +19,7 @@ pub enum Expression {
     Range(Range),
 
     Named(NamedExpression),
+    Verdict(Verdict),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -45,7 +47,6 @@ pub enum NamedExpression {
     JHash(JHash),
     SymHash(SymHash),
     Fib(Fib),
-    Verdict(Verdict),
     Elem(Elem),
     Socket(Socket),
     Osf(Osf),
@@ -346,8 +347,8 @@ pub enum Verdict {
     Drop,
     Continue,
     Return,
-    Jump(String),
-    Goto(String),
+    Jump(JumpTarget),
+    Goto(JumpTarget),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -217,6 +217,8 @@ pub struct Map {
     pub gc_interval: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -197,7 +197,26 @@ pub struct Set {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Map {
-    // TODO
+    pub family: NfFamily,
+    pub table: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handle: Option<u32>,
+    #[serde(rename = "type")]
+    pub set_type: SetTypeValue,
+    pub map: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy: Option<SetPolicy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flags: Option<HashSet<SetFlag>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elem: Option<Vec<Expression>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u32>,
+    #[serde(rename = "gc-interval", skip_serializing_if = "Option::is_none")]
+    pub gc_interval: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u32>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/tests/helper_tests.rs
+++ b/tests/helper_tests.rs
@@ -73,6 +73,7 @@ fn example_ruleset() -> schema::Nftables {
         timeout: None,
         gc_interval: None,
         size: None,
+        comment: None,
     }));
     // add element to set
     batch.add(schema::NfListObject::Element(schema::Element {

--- a/tests/helper_tests.rs
+++ b/tests/helper_tests.rs
@@ -58,6 +58,22 @@ fn example_ruleset() -> schema::Nftables {
         gc_interval: None,
         size: None,
     }));
+    let map_name = "test_map".to_string();
+    let map_type = "verdict".to_string();
+    batch.add(schema::NfListObject::Map(schema::Map {
+        family: types::NfFamily::IP,
+        table: table_name.clone(),
+        name: map_name.clone(),
+        handle: None,
+        map: map_type.clone(),
+        set_type: schema::SetTypeValue::Single(schema::SetType::Ipv4Addr),
+        policy: None,
+        flags: None,
+        elem: None,
+        timeout: None,
+        gc_interval: None,
+        size: None,
+    }));
     // add element to set
     batch.add(schema::NfListObject::Element(schema::Element {
         family: types::NfFamily::IP,


### PR DESCRIPTION
A Verdict enum was moved from a NamedExpression to an Expression, placing it in a NamedExpression was a bug. Accroding to libnftables-json(5) (section VERDICT) a Verdict does not have a "verdict" key, it is "anonymous". e.g.: { "jump": { "target": "my_target"}, and not: { "verdict": { "jump": { "target": "my_target"} } }

Additionally a `Verdict::Jump` and a `Verdict::Goto` data was changed to a `stmt::JumpTarget` struct from a `String`.

A `Map` and a `Set` use almost the same fields, a map additinally uses a map field of type `String`.