### PR TITLE
fix payload raw expression

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -34,8 +34,7 @@ pub enum NamedExpression {
     Prefix(Prefix),
 
     Payload(Payload),
-    #[serde(rename = "payload")]
-    PayloadRaw(PayloadRaw),
+
     Exthdr(Exthdr),
     #[serde(rename = "tcp option")]
     TcpOption(TcpOption),
@@ -92,20 +91,25 @@ pub struct Range {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename = "payload")]
-/// Construct a payload expression, i.e. a reference to a certain part of packet data.
-/// Creates a raw payload expression to point at a random number (`len`) of bytes at a certain offset (`offset`) from a given reference point (`base`).
-pub struct PayloadRaw {
-    base: PayloadBase,
-    offset: u32,
-    len: u32,
+#[serde(untagged)]
+pub enum Payload {
+    PayloadField(PayloadField),
+    PayloadRaw(PayloadRaw),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename = "payload")]
+/// Construct a payload expression, i.e. a reference to a certain part of packet data.
+/// Creates a raw payload expression to point at a random number (`len`) of bytes at a certain offset (`offset`) from a given reference point (`base`).
+pub struct PayloadRaw {
+    pub base: PayloadBase,
+    pub offset: u32,
+    pub len: u32,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 /// Construct a payload expression, i.e. a reference to a certain part of packet data.
 /// Allows to reference a field by name (`field`) in a named packet header (`protocol`).
-pub struct Payload {
+pub struct PayloadField {
     pub protocol: String,
     pub field: String,
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -115,7 +115,7 @@ pub struct PayloadField {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename = "payload", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 /// Represents a protocol layer for `payload` references.
 pub enum PayloadBase {
     /// Link layer, for example the Ethernet header
@@ -124,6 +124,8 @@ pub enum PayloadBase {
     NH,
     /// Transport Header, for example TCP
     TH,
+    /// Inner Header / Payload, i.e. after the L4 transport level header
+    IH,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
The current code cannot handle the ParloadRaw type, serde is unable to deserialize the json with a raw payload fields.

This is because serde cannot handle two fields with the same name and I haven't found a way to make this work like that. Instead we have to use a untagged enum that share both possible payload values.

Therefore this is an API break: NamedExpression now only contains one Payload field which contains the Payload enum, the old Payload type is renamed to PayloadField.

Lastly, export the PayloadRaw fields so they can be used externally.