### PR TITLE
Run nft tests in netns

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run Clippy
       run: cargo clippy --all-targets --all-features
     - name: Build
@@ -26,5 +26,5 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Run tests (rootful)
-      run: nft --version; sudo -E $(which cargo) test --verbose -- --ignored
+      run: sudo -E env "PATH=$PATH" $(which cargo) test --verbose -- --ignored
 

--- a/tests/run_nft_tests.sh
+++ b/tests/run_nft_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+NETNS=nft-$(cat /proc/sys/kernel/random/uuid)
+
+function nsexec {
+  ip netns exec $NETNS $@
+}
+
+function cleanup {
+  ip netns delete "$NETNS"
+  exit 0
+}
+trap cleanup EXIT
+
+# create net namespace
+(ip netns ls | grep -Fx "$NETNS" 2>/dev/null) || ip netns add "$NETNS"
+
+nft --version;
+nsexec cargo test --verbose -- --ignored


### PR DESCRIPTION
Tests that use nft command alter the system's nftables.
By creating a fresh net namespace for each run, tests will not break system networking.