### PR TITLE
Add common traits to basic enums

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -114,7 +114,7 @@ pub struct PayloadField {
     pub field: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol layer for `payload` references.
 pub enum PayloadBase {
@@ -161,7 +161,7 @@ pub struct Meta {
     pub key: MetaKey,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a `meta` key for packet meta data.
 pub enum MetaKey {
@@ -203,7 +203,7 @@ pub struct RT {
     pub family: Option<RTFamily>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a key to reference to packet routing data.
 pub enum RTKey {
@@ -212,7 +212,7 @@ pub enum RTKey {
     MTU,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol family for use by the `ct` expression.
 pub enum RTFamily {
@@ -231,7 +231,7 @@ pub struct CT {
     pub dir: Option<CTDir>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol family for use by the `ct` expression.
 pub enum CTFamily {
@@ -239,7 +239,7 @@ pub enum CTFamily {
     IP6,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a direction for use by the `ct` expression.
 pub enum CTDir {
@@ -258,7 +258,7 @@ pub struct Numgen {
     pub offset: Option<u32>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a number generator mode.
 pub enum NgMode {
@@ -296,7 +296,7 @@ pub struct Fib {
     pub flags: HashSet<FibFlag>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents which data is queried by `fib` lookup.
 pub enum FibResult {
@@ -305,7 +305,7 @@ pub enum FibResult {
     Type,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "lowercase")]
 /// Represents flags for `fib` lookup.
 pub enum FibFlag {
@@ -388,7 +388,7 @@ pub struct Osf {
     pub ttl: OsfTtl,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// TTL check mode for `osf`.
 pub enum OsfTtl {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -235,7 +235,7 @@ pub enum SetTypeValue {
     Concatenated(Vec<SetType>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, EnumString)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, EnumString)]
 #[serde(rename_all = "lowercase")]
 /// Describes a set’s datatype.
 pub enum SetType {
@@ -263,7 +263,7 @@ pub enum SetType {
     Ifname,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Describes a set’s policy.
 pub enum SetPolicy {
@@ -271,7 +271,7 @@ pub enum SetPolicy {
     Memory,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "lowercase")]
 /// Describes a set’s flags.
 pub enum SetFlag {
@@ -281,7 +281,7 @@ pub enum SetFlag {
     Dynamic,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Describes an operator on set.
 pub enum SetOp {
@@ -373,7 +373,7 @@ pub struct Limit {
     pub inv: Option<bool>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum LimitUnit {
     Packets,

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -187,7 +187,7 @@ pub struct FWD {
     pub addr: Option<Expression>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Protocol family for `FWD`.
 pub enum FWDFamily {
@@ -223,7 +223,7 @@ pub struct NAT {
     pub flags: Option<HashSet<NATFlag>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Protocol family for `NAT`.
 pub enum NATFamily {
@@ -231,7 +231,7 @@ pub enum NATFamily {
     IP6,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "lowercase")]
 /// Flags for `NAT`.
 pub enum NATFlag {
@@ -258,7 +258,7 @@ impl Reject {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Types of `Reject`.
 pub enum RejectType {
@@ -280,7 +280,7 @@ pub struct Set {
     pub set: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Operators on `Set`.
 pub enum SetOp {
@@ -334,7 +334,7 @@ impl Log {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Levels of `Log`.
 pub enum LogLevel {
@@ -349,7 +349,7 @@ pub enum LogLevel {
     Audit,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash, EnumString)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, EnumString)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 /// Flags of `Log`.
@@ -389,7 +389,7 @@ pub struct Queue {
     pub flags: Option<HashSet<QueueFlag>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "lowercase")]
 /// Flags of `Queue`.
 pub enum QueueFlag {
@@ -420,7 +420,7 @@ pub struct CTCount {
     pub inv: Option<bool>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 /// Represents an operator for `Match`.
 pub enum Operator {
     #[serde(rename = "&")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 /// Families in nftables.
 ///
 /// See <https://wiki.nftables.org/wiki-nftables/index.php/Nftables_families>.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum NfFamily {
     IP,
@@ -14,7 +14,7 @@ pub enum NfFamily {
     NetDev,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents the type of a Chain.
 pub enum NfChainType {
@@ -23,7 +23,7 @@ pub enum NfChainType {
     NAT,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents the policy of a Chain.
 pub enum NfChainPolicy {
@@ -31,7 +31,7 @@ pub enum NfChainPolicy {
     Drop,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a netfilter hook.
 ///
@@ -46,7 +46,7 @@ pub enum NfHook {
     Egress,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 /// Represents a conntrack helper protocol.
 pub enum CTHProto {
@@ -60,7 +60,7 @@ pub enum CTHProto {
     Generic,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum RejectCode {
     #[serde(rename = "admin-prohibited")]
     /// Host administratively prohibited (ICMPX, ICMP, ICMPv6)


### PR DESCRIPTION
This PR adds some common traits (`Hash` and `Copy`) from [Rust's API guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html) to the crate's basic enum types.

I recently needed to create a HashMap using `(String, NfFamily)` as keys and couldn't since `NfFamily` didn't implement `Hash`. I added `Copy` as well for good measure since these enums are all 1 byte large.