### PR TITLE
feat: add support for tproxy

### DIFF
--- a/resources/test/json/tproxy.json
+++ b/resources/test/json/tproxy.json
@@ -1,0 +1,144 @@
+{
+  "nftables": [
+    {
+      "metainfo": {
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
+        "json_schema_version": 1
+      }
+    },
+    {
+      "table": {
+        "family": "inet",
+        "name": "filter",
+        "handle": 1
+      }
+    },
+    {
+      "chain": {
+        "family": "inet",
+        "table": "filter",
+        "name": "tproxy_ipv4",
+        "handle": 1
+      }
+    },
+    {
+      "chain": {
+        "family": "inet",
+        "table": "filter",
+        "name": "tproxy_ipv6",
+        "handle": 2
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "filter",
+        "chain": "tproxy_ipv4",
+        "handle": 3,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "meta": {
+                  "key": "l4proto"
+                }
+              },
+              "right": "tcp"
+            }
+          },
+          {
+            "tproxy": {
+              "family": "ip",
+              "addr": "127.0.0.1",
+              "port": 12345
+            }
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "filter",
+        "chain": "tproxy_ipv4",
+        "handle": 4,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "meta": {
+                  "key": "l4proto"
+                }
+              },
+              "right": "tcp"
+            }
+          },
+          {
+            "tproxy": {
+              "family": "ip",
+              "port": 12345
+            }
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "filter",
+        "chain": "tproxy_ipv6",
+        "handle": 5,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "meta": {
+                  "key": "l4proto"
+                }
+              },
+              "right": "tcp"
+            }
+          },
+          {
+            "tproxy": {
+              "family": "ip6",
+              "addr": "::1",
+              "port": 12345
+            }
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "filter",
+        "chain": "tproxy_ipv6",
+        "handle": 6,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "meta": {
+                  "key": "l4proto"
+                }
+              },
+              "right": "tcp"
+            }
+          },
+          {
+            "tproxy": {
+              "family": "ip6",
+              "port": 12345
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/resources/test/nft/tproxy.nft
+++ b/resources/test/nft/tproxy.nft
@@ -1,0 +1,16 @@
+#!/sbin/nft -f
+
+flush ruleset
+
+table inet filter {
+
+	chain tproxy_ipv4 {
+	     meta l4proto tcp tproxy ip to 127.0.0.1:12345
+	     meta l4proto tcp tproxy ip to :12345
+	}
+
+	chain tproxy_ipv6 {
+	     meta l4proto tcp tproxy ip6 to [::1]:12345
+	     meta l4proto tcp tproxy ip6 to :12345
+	}
+}

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -75,6 +75,8 @@ pub enum Statement {
     /// This represents an xt statement from xtables compat interface.
     /// Sadly, at this point, it is not possible to provide any further information about its content.
     XT(Option<serde_json::Value>),
+
+    TProxy(TProxy),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -418,6 +420,16 @@ pub struct CTCount {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// If `true`, match if `val` was exceeded. If omitted, defaults to `false`.
     pub inv: Option<bool>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct TProxy {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    pub port: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub addr: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
This add supports for [TPROXY](https://docs.kernel.org/networking/tproxy.html#redirecting-traffic) which is not documented in the [man page](https://manpages.debian.org/unstable/libnftables1/libnftables-json.5.en.html)