### PR TITLE
Fix named counter statements

### DIFF
--- a/resources/test/json/basic.json
+++ b/resources/test/json/basic.json
@@ -2,8 +2,8 @@
   "nftables": [
     {
       "metainfo": {
-        "version": "0.9.8",
-        "release_name": "E.D.S.",
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
         "json_schema_version": 1
       }
     },
@@ -11,7 +11,7 @@
       "table": {
         "family": "ip",
         "name": "filter",
-        "handle": 59
+        "handle": 1
       }
     },
     {
@@ -36,6 +36,18 @@
         "hook": "input",
         "prio": 0,
         "policy": "accept"
+      }
+    },
+    {
+      "chain": {
+        "family": "ip",
+        "table": "filter",
+        "name": "forward",
+        "handle": 3,
+        "type": "filter",
+        "hook": "forward",
+        "prio": 0,
+        "policy": "drop"
       }
     },
     {
@@ -84,18 +96,6 @@
             "drop": null
           }
         ]
-      }
-    },
-    {
-      "chain": {
-        "family": "ip",
-        "table": "filter",
-        "name": "forward",
-        "handle": 3,
-        "type": "filter",
-        "hook": "forward",
-        "prio": 0,
-        "policy": "drop"
       }
     },
     {

--- a/resources/test/json/counter.json
+++ b/resources/test/json/counter.json
@@ -1,0 +1,150 @@
+{
+  "nftables": [
+    {
+      "metainfo": {
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
+        "json_schema_version": 1
+      }
+    },
+    {
+      "table": {
+        "family": "inet",
+        "name": "named_counter_demo",
+        "handle": 1
+      }
+    },
+    {
+      "counter": {
+        "family": "inet",
+        "name": "cnt_http",
+        "table": "named_counter_demo",
+        "handle": 2,
+        "comment": "count both http and https packets",
+        "packets": 0,
+        "bytes": 0
+      }
+    },
+    {
+      "counter": {
+        "family": "inet",
+        "name": "cnt_smtp",
+        "table": "named_counter_demo",
+        "handle": 3,
+        "packets": 0,
+        "bytes": 0
+      }
+    },
+    {
+      "chain": {
+        "family": "inet",
+        "table": "named_counter_demo",
+        "name": "IN",
+        "handle": 1
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "named_counter_demo",
+        "chain": "IN",
+        "handle": 4,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "payload": {
+                  "protocol": "tcp",
+                  "field": "dport"
+                }
+              },
+              "right": 21
+            }
+          },
+          {
+            "counter": {
+              "packets": 0,
+              "bytes": 0
+            }
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "named_counter_demo",
+        "chain": "IN",
+        "handle": 5,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "payload": {
+                  "protocol": "tcp",
+                  "field": "dport"
+                }
+              },
+              "right": 25
+            }
+          },
+          {
+            "counter": "cnt_smtp"
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "named_counter_demo",
+        "chain": "IN",
+        "handle": 6,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "payload": {
+                  "protocol": "tcp",
+                  "field": "dport"
+                }
+              },
+              "right": 80
+            }
+          },
+          {
+            "counter": "cnt_http"
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "named_counter_demo",
+        "chain": "IN",
+        "handle": 7,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "payload": {
+                  "protocol": "tcp",
+                  "field": "dport"
+                }
+              },
+              "right": 443
+            }
+          },
+          {
+            "counter": "cnt_http"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/resources/test/json/nat.json
+++ b/resources/test/json/nat.json
@@ -2,8 +2,8 @@
   "nftables": [
     {
       "metainfo": {
-        "version": "0.9.8",
-        "release_name": "E.D.S.",
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
         "json_schema_version": 1
       }
     },
@@ -11,7 +11,7 @@
       "table": {
         "family": "ip",
         "name": "nat",
-        "handle": 60
+        "handle": 1
       }
     },
     {

--- a/resources/test/json/nftables-init.json
+++ b/resources/test/json/nftables-init.json
@@ -2,8 +2,8 @@
   "nftables": [
     {
       "metainfo": {
-        "version": "0.9.8",
-        "release_name": "E.D.S.",
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
         "json_schema_version": 1
       }
     },
@@ -11,7 +11,7 @@
       "table": {
         "family": "ip",
         "name": "nat",
-        "handle": 61
+        "handle": 1
       }
     },
     {
@@ -22,6 +22,18 @@
         "handle": 1,
         "type": "nat",
         "hook": "prerouting",
+        "prio": 0,
+        "policy": "accept"
+      }
+    },
+    {
+      "chain": {
+        "family": "ip",
+        "table": "nat",
+        "name": "postrouting",
+        "handle": 2,
+        "type": "nat",
+        "hook": "postrouting",
         "prio": 0,
         "policy": "accept"
       }
@@ -67,22 +79,10 @@
       }
     },
     {
-      "chain": {
-        "family": "ip",
-        "table": "nat",
-        "name": "postrouting",
-        "handle": 2,
-        "type": "nat",
-        "hook": "postrouting",
-        "prio": 0,
-        "policy": "accept"
-      }
-    },
-    {
       "table": {
         "family": "inet",
         "name": "filter",
-        "handle": 62
+        "handle": 2
       }
     },
     {
@@ -111,11 +111,31 @@
       }
     },
     {
+      "chain": {
+        "family": "inet",
+        "table": "filter",
+        "name": "output",
+        "handle": 2,
+        "type": "filter",
+        "hook": "output",
+        "prio": 0,
+        "policy": "accept"
+      }
+    },
+    {
+      "chain": {
+        "family": "inet",
+        "table": "filter",
+        "name": "admin",
+        "handle": 3
+      }
+    },
+    {
       "rule": {
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 14,
+        "handle": 5,
         "expr": [
           {
             "match": {
@@ -140,7 +160,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 15,
+        "handle": 6,
         "expr": [
           {
             "match": {
@@ -167,7 +187,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 16,
+        "handle": 7,
         "expr": [
           {
             "match": {
@@ -191,7 +211,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 17,
+        "handle": 8,
         "expr": [
           {
             "match": {
@@ -232,7 +252,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 18,
+        "handle": 9,
         "expr": [
           {
             "match": {
@@ -245,20 +265,16 @@
                       "field": "flags"
                     }
                   },
-                  {
-                    "|": [
-                      "fin",
-                      "syn"
-                    ]
-                  }
+                  [
+                    "fin",
+                    "syn"
+                  ]
                 ]
               },
-              "right": {
-                "|": [
-                  "fin",
-                  "syn"
-                ]
-              }
+              "right": [
+                "fin",
+                "syn"
+              ]
             }
           },
           {
@@ -277,7 +293,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 19,
+        "handle": 10,
         "expr": [
           {
             "match": {
@@ -290,20 +306,16 @@
                       "field": "flags"
                     }
                   },
-                  {
-                    "|": [
-                      "syn",
-                      "rst"
-                    ]
-                  }
+                  [
+                    "syn",
+                    "rst"
+                  ]
                 ]
               },
-              "right": {
-                "|": [
-                  "syn",
-                  "rst"
-                ]
-              }
+              "right": [
+                "syn",
+                "rst"
+              ]
             }
           },
           {
@@ -322,7 +334,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 20,
+        "handle": 11,
         "expr": [
           {
             "match": {
@@ -382,7 +394,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 21,
+        "handle": 12,
         "expr": [
           {
             "match": {
@@ -395,45 +407,21 @@
                       "field": "flags"
                     }
                   },
-                  {
-                    "|": [
-                      {
-                        "|": [
-                          {
-                            "|": [
-                              {
-                                "|": [
-                                  {
-                                    "|": [
-                                      "fin",
-                                      "syn"
-                                    ]
-                                  },
-                                  "rst"
-                                ]
-                              },
-                              "psh"
-                            ]
-                          },
-                          "ack"
-                        ]
-                      },
-                      "urg"
-                    ]
-                  }
+                  [
+                    "fin",
+                    "syn",
+                    "rst",
+                    "psh",
+                    "ack",
+                    "urg"
+                  ]
                 ]
               },
-              "right": {
-                "|": [
-                  {
-                    "|": [
-                      "fin",
-                      "psh"
-                    ]
-                  },
-                  "urg"
-                ]
-              }
+              "right": [
+                "fin",
+                "psh",
+                "urg"
+              ]
             }
           },
           {
@@ -452,7 +440,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 22,
+        "handle": 13,
         "expr": [
           {
             "match": {
@@ -488,7 +476,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 23,
+        "handle": 15,
         "expr": [
           {
             "match": {
@@ -530,7 +518,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 24,
+        "handle": 17,
         "expr": [
           {
             "match": {
@@ -578,7 +566,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 25,
+        "handle": 19,
         "expr": [
           {
             "match": {
@@ -617,6 +605,7 @@
           {
             "limit": {
               "rate": 100,
+              "burst": 5,
               "per": "second"
             }
           },
@@ -631,7 +620,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 26,
+        "handle": 21,
         "expr": [
           {
             "match": {
@@ -667,6 +656,7 @@
           {
             "limit": {
               "rate": 100,
+              "burst": 5,
               "per": "second"
             }
           },
@@ -677,23 +667,11 @@
       }
     },
     {
-      "chain": {
-        "family": "inet",
-        "table": "filter",
-        "name": "output",
-        "handle": 2,
-        "type": "filter",
-        "hook": "output",
-        "prio": 0,
-        "policy": "accept"
-      }
-    },
-    {
       "rule": {
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 27,
+        "handle": 22,
         "expr": [
           {
             "match": {
@@ -720,7 +698,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 28,
+        "handle": 23,
         "expr": [
           {
             "match": {
@@ -744,7 +722,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 29,
+        "handle": 25,
         "expr": [
           {
             "match": {
@@ -786,7 +764,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 30,
+        "handle": 27,
         "expr": [
           {
             "match": {
@@ -828,7 +806,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 31,
+        "handle": 28,
         "expr": [
           {
             "match": {
@@ -853,7 +831,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 32,
+        "handle": 29,
         "expr": [
           {
             "match": {
@@ -878,7 +856,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 33,
+        "handle": 31,
         "expr": [
           {
             "match": {
@@ -907,11 +885,7 @@
                   "field": "daddr"
                 }
               },
-              "right": {
-                "set": [
-                  "127.0.0.1"
-                ]
-              }
+              "right": "127.0.0.1"
             }
           },
           {
@@ -930,7 +904,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 34,
+        "handle": 33,
         "expr": [
           {
             "match": {
@@ -971,7 +945,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 35,
+        "handle": 34,
         "expr": [
           {
             "match": {
@@ -1000,6 +974,7 @@
           {
             "limit": {
               "rate": 1,
+              "burst": 5,
               "per": "second"
             }
           },
@@ -1017,7 +992,7 @@
         "family": "inet",
         "table": "filter",
         "chain": "output",
-        "handle": 36,
+        "handle": 35,
         "expr": [
           {
             "log": {
@@ -1029,19 +1004,11 @@
       }
     },
     {
-      "chain": {
-        "family": "inet",
-        "table": "filter",
-        "name": "admin",
-        "handle": 3
-      }
-    },
-    {
       "rule": {
         "family": "inet",
         "table": "filter",
         "chain": "admin",
-        "handle": 37,
+        "handle": 36,
         "expr": [
           {
             "match": {

--- a/resources/test/json/space-keys.json
+++ b/resources/test/json/space-keys.json
@@ -2,8 +2,8 @@
   "nftables": [
     {
       "metainfo": {
-        "version": "1.0.7",
-        "release_name": "Old Doc Yak",
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
         "json_schema_version": 1
       }
     },

--- a/resources/test/json/workstation.json
+++ b/resources/test/json/workstation.json
@@ -2,8 +2,8 @@
   "nftables": [
     {
       "metainfo": {
-        "version": "0.9.8",
-        "release_name": "E.D.S.",
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
         "json_schema_version": 1
       }
     },
@@ -11,7 +11,7 @@
       "table": {
         "family": "ip",
         "name": "filter",
-        "handle": 63
+        "handle": 1
       }
     },
     {
@@ -27,11 +27,35 @@
       }
     },
     {
+      "chain": {
+        "family": "ip",
+        "table": "filter",
+        "name": "forward",
+        "handle": 2,
+        "type": "filter",
+        "hook": "forward",
+        "prio": 0,
+        "policy": "drop"
+      }
+    },
+    {
+      "chain": {
+        "family": "ip",
+        "table": "filter",
+        "name": "output",
+        "handle": 3,
+        "type": "filter",
+        "hook": "output",
+        "prio": 0,
+        "policy": "accept"
+      }
+    },
+    {
       "rule": {
         "family": "ip",
         "table": "filter",
         "chain": "input",
-        "handle": 5,
+        "handle": 4,
         "comment": "early drop of invalid packets",
         "expr": [
           {
@@ -248,18 +272,6 @@
       }
     },
     {
-      "chain": {
-        "family": "ip",
-        "table": "filter",
-        "name": "forward",
-        "handle": 2,
-        "type": "filter",
-        "hook": "forward",
-        "prio": 0,
-        "policy": "drop"
-      }
-    },
-    {
       "rule": {
         "family": "ip",
         "table": "filter",
@@ -274,18 +286,6 @@
             }
           }
         ]
-      }
-    },
-    {
-      "chain": {
-        "family": "ip",
-        "table": "filter",
-        "name": "output",
-        "handle": 3,
-        "type": "filter",
-        "hook": "output",
-        "prio": 0,
-        "policy": "accept"
       }
     },
     {
@@ -309,7 +309,7 @@
       "table": {
         "family": "ip6",
         "name": "filter",
-        "handle": 64
+        "handle": 2
       }
     },
     {
@@ -325,11 +325,35 @@
       }
     },
     {
+      "chain": {
+        "family": "ip6",
+        "table": "filter",
+        "name": "forward",
+        "handle": 2,
+        "type": "filter",
+        "hook": "forward",
+        "prio": 0,
+        "policy": "drop"
+      }
+    },
+    {
+      "chain": {
+        "family": "ip6",
+        "table": "filter",
+        "name": "output",
+        "handle": 3,
+        "type": "filter",
+        "hook": "output",
+        "prio": 0,
+        "policy": "accept"
+      }
+    },
+    {
       "rule": {
         "family": "ip6",
         "table": "filter",
         "chain": "input",
-        "handle": 5,
+        "handle": 4,
         "comment": "early drop of invalid packets",
         "expr": [
           {
@@ -541,18 +565,6 @@
       }
     },
     {
-      "chain": {
-        "family": "ip6",
-        "table": "filter",
-        "name": "forward",
-        "handle": 2,
-        "type": "filter",
-        "hook": "forward",
-        "prio": 0,
-        "policy": "drop"
-      }
-    },
-    {
       "rule": {
         "family": "ip6",
         "table": "filter",
@@ -567,18 +579,6 @@
             }
           }
         ]
-      }
-    },
-    {
-      "chain": {
-        "family": "ip6",
-        "table": "filter",
-        "name": "output",
-        "handle": 3,
-        "type": "filter",
-        "hook": "output",
-        "prio": 0,
-        "policy": "accept"
       }
     },
     {

--- a/resources/test/json/workstation_combined.json
+++ b/resources/test/json/workstation_combined.json
@@ -2,8 +2,8 @@
   "nftables": [
     {
       "metainfo": {
-        "version": "0.9.8",
-        "release_name": "E.D.S.",
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
         "json_schema_version": 1
       }
     },
@@ -11,7 +11,7 @@
       "table": {
         "family": "inet",
         "name": "filter",
-        "handle": 65
+        "handle": 1
       }
     },
     {
@@ -27,11 +27,35 @@
       }
     },
     {
+      "chain": {
+        "family": "inet",
+        "table": "filter",
+        "name": "forward",
+        "handle": 2,
+        "type": "filter",
+        "hook": "forward",
+        "prio": 0,
+        "policy": "drop"
+      }
+    },
+    {
+      "chain": {
+        "family": "inet",
+        "table": "filter",
+        "name": "output",
+        "handle": 3,
+        "type": "filter",
+        "hook": "output",
+        "prio": 0,
+        "policy": "accept"
+      }
+    },
+    {
       "rule": {
         "family": "inet",
         "table": "filter",
         "chain": "input",
-        "handle": 5,
+        "handle": 4,
         "comment": "early drop of invalid packets",
         "expr": [
           {
@@ -323,18 +347,6 @@
       }
     },
     {
-      "chain": {
-        "family": "inet",
-        "table": "filter",
-        "name": "forward",
-        "handle": 2,
-        "type": "filter",
-        "hook": "forward",
-        "prio": 0,
-        "policy": "drop"
-      }
-    },
-    {
       "rule": {
         "family": "inet",
         "table": "filter",
@@ -349,18 +361,6 @@
             }
           }
         ]
-      }
-    },
-    {
-      "chain": {
-        "family": "inet",
-        "table": "filter",
-        "name": "output",
-        "handle": 3,
-        "type": "filter",
-        "hook": "output",
-        "prio": 0,
-        "policy": "accept"
       }
     },
     {

--- a/resources/test/nft/counter.nft
+++ b/resources/test/nft/counter.nft
@@ -1,0 +1,17 @@
+table inet named_counter_demo {
+	counter cnt_http {
+		comment "count both http and https packets"
+		packets 0 bytes 0
+	}
+
+	counter cnt_smtp {
+		packets 0 bytes 0
+	}
+
+	chain IN {
+		tcp dport 21 counter
+		tcp dport 25 counter name "cnt_smtp"
+		tcp dport 80 counter name "cnt_http"
+		tcp dport 443 counter name "cnt_http"
+	}
+}

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -29,10 +29,8 @@ pub enum Statement {
     Goto(JumpTarget),
 
     Match(Match),
-    Counter(Option<Counter>),
-    #[serde(rename = "counter")]
-    /// reference to a named counter
-    CounterRef(String),
+    /// anonymous or named counter.
+    Counter(Counter),
     Mangle(Mangle),
     Quota(Quota),
     #[serde(rename = "quota")]
@@ -116,10 +114,18 @@ pub struct Match {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+/// Anonymous or named Counter.
+pub enum Counter {
+    Named(String),
+    Anonymous(Option<AnonymousCounter>),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 /// This object represents a byte/packet counter.
 /// In input, no properties are required.
 /// If given, they act as initial values for the counter.
-pub struct Counter {
+pub struct AnonymousCounter {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Packets counted.
     pub packets: Option<usize>,

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -117,11 +117,13 @@ pub struct Match {
 #[serde(untagged)]
 /// Anonymous or named Counter.
 pub enum Counter {
+    /// A counter referenced by name.
     Named(String),
+    /// An anonymous counter.
     Anonymous(Option<AnonymousCounter>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 /// This object represents a byte/packet counter.
 /// In input, no properties are required.
 /// If given, they act as initial values for the counter.

--- a/tests/json_tests.rs
+++ b/tests/json_tests.rs
@@ -1,5 +1,5 @@
 use nftables::expr::{Expression, Meta, MetaKey, NamedExpression};
-use nftables::stmt::{Match, Operator, Queue, Statement};
+use nftables::stmt::{Counter, Match, Operator, Queue, Statement};
 use nftables::{schema::*, types::*};
 use serde_json::json;
 use std::fs::{self, File};
@@ -77,7 +77,7 @@ fn test_insert() {
                         right: Expression::String("wg_exit".to_string()),
                         op: Operator::EQ,
                     }),
-                    Statement::Counter(None),
+                    Statement::Counter(Counter::Anonymous(None)),
                     Statement::Accept(None),
                 ],
                 handle: None,


### PR DESCRIPTION
Changed `Counter` enum variants for serde to properly match named counters.

Old usage:
```rust
Statement::Counter(None)
```

New usage:
```rust
Statement::Counter(Counter::Anonymous(stmt::AnonymousCounter {
  bytes: None,
  packets: None,
}))
# or
Statement::Counter(Counter::Named("count_packets".to_string()))
```

Closes #45.