### PR TITLE
Mark Statement as non-exhaustive enum

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -11,6 +11,7 @@ use crate::expr::Expression;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 /// Statements are the building blocks for rules. Each rule consists of at least one.
 ///
 /// See <https://manpages.debian.org/testing/libnftables1/libnftables-json.5.en.html#STATEMENTS>.


### PR DESCRIPTION
Introducing `non-exhaustive` mark to `Statement` enum avoids future breaking changes when statements are added by forcing users to add a wildcard arm to match on statement.

Proposed in #70.