### PR TITLE
Add @JKRhb as maintainer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ dual licensed as above, without any additional terms or conditions.
 
 This project is currently maintained by the following developers:
 
-|       Name       |      Email Address     |                GitHub Username               |
-|:----------------:|:----------------------:|:--------------------------------------------:|
-| Jasper Wiegratz  | wiegratz@uni-bremen.de |       [@jwhb](https://github.com/jwhb)       |
+|       Name       |      Email Address       |                GitHub Username               |
+|:----------------:|:------------------------:|:--------------------------------------------:|
+| Jasper Wiegratz  | wiegratz@uni-bremen.de   |       [@jwhb](https://github.com/jwhb)       |
+| Jan Romann       | jan.romann@uni-bremen.de |      [@JKRhb](https://github.com/JKRhb)      |
 
+Write access to the main branch and to crates.io is exclusively granted to the maintainers listed above.


### PR DESCRIPTION
This adds @JKRhb to the list of maintainers.

As a fellow project member of the [NAMIB project](https://github.com/namib-project) (2020-2022), Jan witnessed the inception of *nftables-rs* (which was named *nft-rs* at that time). Jan has made [multiple contributions](https://github.com/namib-project/nftables-rs/commits?author=JKRhb) to this project and reviews pull requests.
He was added as a co-owner of the [nftables crate](https://crates.io/crates/nftables) about 6 months ago and has had push access to this repository ever since.


Currently @jwhb and @JKRhb have exclusive push permissions to the GitHub repository and exclusive ownership of the crate.

There have been no recent security changes; this documentation update is solely for transparency.